### PR TITLE
0.3.6

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,41 @@
-# eager2poseidon 0.4.0
+# eager2poseidon 0.3.6
+
+## [0.3.6] - 2023-05-10
+
+### `Added`
+
+### `Fixed`
+
+- `fill_in_janno()`: Now correctly keeps `Relation_*` columns.
+- `fill_genetic_sex()`: Should now work with newer R and pacakge versions.
+- `read_eager_stats_table()`: Eager tables are now joined with eager TSV to allow for sample names that include `_` before the first `.`.
+- `read_eager_stats_table()`: Use `sprintf` instead of `format` for formatting decimals. Should avoid `digits=0` error in newer R versions.
+- `eager2poseidon.R`: Added explicit `.cols` statement to `mutate`. needed for newer dplyr versions.
+
+### `Dependencies`
+
+### `Deprecated`
+
+# eager2poseidon 0.3.5
+
+## [0.3.5] - 2023-03-01
+
+### `Added`
+
+### `Fixed`
+
+- `compile_eager_result_tables()`: Corrected column name for number of libraries. `Nr_Libs` -> `Nr_Libraries`. Closes #4 
+- `compile_across_lib_results()`: Inference of `Nr_Libraries` corrected to count only unique values. This also fixed inference of `Capture_Type`. Closes #5 
+- `compile_across_lib_results()`: Corrected weighted sum calculation to only include unique rows of library-level data. Closes #6 
+- `compile_across_lib_results()`: Corrected `Library_Names` field. Now includes only unique library names.
+
+### `Dependencies`
+
+- Added `vctrs` to package dependencies
+
+### `Deprecated`
+
+# eager2poseidon 0.3.2
 
 * Update C14 quickcalibrate backend for compatibility with `poseidonR` v0.9.0.
 

--- a/exec/eager2poseidon.R
+++ b/exec/eager2poseidon.R
@@ -98,6 +98,7 @@ output_janno <- fill_in_janno(
 output_janno <- output_janno %>%
   dplyr::mutate(
     dplyr::across(
+      .cols = everything(),
       .fn = as.character
     )
   ) %>%


### PR DESCRIPTION
## [0.3.6] - 2023-05-10

### `Added`

### `Fixed`

- `fill_in_janno()`: Now correctly keeps `Relation_*` columns.
- `fill_genetic_sex()`: Should now work with newer R and pacakge versions.
- `read_eager_stats_table()`: Eager tables are now joined with eager TSV to allow for sample names that include `_` before the first `.`.
- `read_eager_stats_table()`: Use `sprintf` instead of `format` for formatting decimals. Should avoid `digits=0` error in newer R versions.
- `eager2poseidon.R`: Added explicit `.cols` statement to `mutate`. needed for newer dplyr versions.

### `Dependencies`

### `Deprecated`